### PR TITLE
Example of adding a new page

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
     - open the repository folder
     - open `cmd` command line window
     - type: `python.exe web2py.py` to launch a local server
+	- **Note**: can also run the `launch_dev.bat` script (uses the same commands as above)
 ### Workflow
 * Name any personal/feature branches whatever you want
 * `development` branch is what is deployed to [dataprocessing.pythonanywhere.com](https://dataprocessing.pythonanywhere.com/welcome/default/index)

--- a/applications/welcome/controllers/league_creation.py
+++ b/applications/welcome/controllers/league_creation.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+# -------------------------------------------------------------------------
+# This is a sample controller
+# this file is released under public domain and you can use without limitations
+# -------------------------------------------------------------------------
+
+# ---- example index page ----
+def index():
+    response.flash = T("Leage Creation!")
+    return dict(message=T('League Creation'))
+
+# ---- API (example) -----
+@auth.requires_login()
+def api_get_user_email():
+    if not request.env.request_method == 'GET': raise HTTP(403)
+    return response.json({'status':'success', 'email':auth.user.email})
+
+# ---- Smart Grid (example) -----
+@auth.requires_membership('admin') # can only be accessed by members of admin groupd
+def grid():
+    response.view = 'generic.html' # use a generic view
+    tablename = request.args(0)
+    if not tablename in db.tables: raise HTTP(403)
+    grid = SQLFORM.smartgrid(db[tablename], args=[tablename], deletable=False, editable=False)
+    return dict(grid=grid)
+
+# ---- Embedded wiki (example) ----
+def wiki():
+    auth.wikimenu() # add the wiki to the menu
+    return auth.wiki() 
+
+# ---- Action for login/register/etc (required for auth) -----
+def user():
+    """
+    exposes:
+    http://..../[app]/default/user/login
+    http://..../[app]/default/user/logout
+    http://..../[app]/default/user/register
+    http://..../[app]/default/user/profile
+    http://..../[app]/default/user/retrieve_password
+    http://..../[app]/default/user/change_password
+    http://..../[app]/default/user/bulk_register
+    use @auth.requires_login()
+        @auth.requires_membership('group name')
+        @auth.requires_permission('read','table name',record_id)
+    to decorate functions that need access control
+    also notice there is http://..../[app]/appadmin/manage/auth to allow administrator to manage users
+    """
+    return dict(form=auth())
+
+# ---- action to server uploaded static content (required) ---
+@cache.action()
+def download():
+    """
+    allows downloading of uploaded files
+    http://..../[app]/default/download/[filename]
+    """
+    return response.download(request, db)

--- a/applications/welcome/views/league_creation/index.html
+++ b/applications/welcome/views/league_creation/index.html
@@ -1,0 +1,53 @@
+{{extend 'layout.html'}}
+
+{{block header}}
+<div class="jumbotron jumbotron-fluid background" style="background-color: #333; color:white; padding:30px;word-wrap:break-word;">
+  <div class="container center">
+    <!--<h1 class="display-5">/{{=request.application}}/{{=request.controller}}/{{=request.function}}</h1>-->
+    <h1 class="display-5">{{=T('Landing Page')}}</h1>
+  </div>
+</div>
+{{end}}
+
+<div class="row">
+  <div class="col-md-12">
+    {{if 'message' in globals():}}
+    <!--<h2>{{=message}}</h2>-->
+    <h2>Welcome to FunkyMon!</h2>
+    <p class="lead">{{=T('How did you get here?')}}</p>
+    <ol style="word-wrap:break-word;">
+      <li>{{=T('You are successfully running web2py')}}</li>
+      <li>{{=XML(T('You visited the url %s', A(request.env.path_info,_href=request.env.path_info)))}}</li>
+      <li>{{=XML(T('Which called the function %s located in the file %s',
+        (A(request.function+'()',_href='#'),
+        A('web2py/applications/%(application)s/controllers/%(controller)s.py' % request,
+        _href=URL('admin','default','peek', args=(request.application,'controllers',request.controller+'.py'))))))}}</li>
+      <li>{{=XML(T('The output of the file is a dictionary that was rendered by the view %s',
+        A('web2py/applications/%(application)s/views/%(controller)s/index.html' % request,
+        _href=URL('admin','default','peek',args=(request.application,'views',request.controller,'index.html')))))}}</li>
+      <li>{{=T('You can modify this application and adapt it to your needs')}}</li>
+    </ol>
+    <div class="jumbotron jumbotron-fluid" style="padding:30px;word-wrap:break-word;">
+      <div class="container center">
+        <a class="btn btn-primary" href="{{=URL('admin','default','index', scheme='https')}}">
+          <i class="fa fa-cog"></i>
+          {{=T("admin")}}
+        </a>
+        <a class="btn btn-secondary" href="{{=URL('examples','default','index')}}">{{=T("Online examples")}}</a>
+        <a class="btn btn-secondary" href="http://web2py.com">web2py.com</a>
+        <a class="btn btn-secondary" href="http://web2py.com/book">{{=T('Documentation')}}</a>
+        <a class="btn btn-secondary" href="{{=URL('default','api_get_user_email')}}">{{=T('API Example')}}</a>
+        <a class="btn btn-secondary" href="{{=URL('default','grid/auth_user')}}">{{=T('Grid Example')}}</a>
+        <a class="btn btn-secondary" href="{{=URL('default','wiki')}}">{{=T('Wiki Example')}}</a>
+      </div>
+    </div>
+    {{elif 'content' in globals():}}
+    {{=content}}
+    {{else:}}
+    {{=BEAUTIFY(response._vars)}}
+    {{pass}}
+  </div>
+</div>
+
+
+

--- a/applications/welcome/views/league_creation/user.html
+++ b/applications/welcome/views/league_creation/user.html
@@ -1,0 +1,33 @@
+{{extend 'layout.html'}}
+
+<div class="row"> 
+  <div id="web2py_user_form" class="col-lg-6" style="background-color:white; margin: 0 auto 5px auto; box-shadow: 0 0 5px #a1a1a1; border-radius:5px;padding: 20px">
+    <h2>
+      {{=T('Sign Up') if request.args(0) == 'register' else T('Log In') if request.args(0) == 'login' else T(request.args(0).replace('_',' ').title())}}
+    </h2>
+    {{=form}}
+    {{if request.args(0)=='login' and not 'register' in auth.settings.actions_disabled:}}
+    <a href="{{=URL('user/register')}}">{{=T('Register')}}</a>
+    <br/>
+    {{pass}}
+    {{if request.args(0)=='login' and not 'retrieve_password' in auth.settings.actions_disabled:}}
+    <a href="{{=URL('user/retrieve_password')}}">{{=T('Lost your password?')}}</a>
+    {{pass}}
+    {{if request.args(0)=='register':}}
+    <a href="{{=URL('user/login')}}">{{=T('Login')}}</a>
+    {{pass}}
+  </div>
+</div>
+
+
+
+{{block page_js}}
+<script>
+    jQuery("#web2py_user_form input:visible:enabled:first").focus();
+{{if request.args(0)=='register':}}
+    web2py_validate_entropy(jQuery('#auth_user_password'),100);
+{{elif request.args(0)=='change_password':}}
+    web2py_validate_entropy(jQuery('#no_table_new_password'),100);
+{{pass}}
+</script>
+{{end page_js}}

--- a/launch_dev.bat
+++ b/launch_dev.bat
@@ -1,0 +1,1 @@
+python.exe web2py.py


### PR DESCRIPTION
Adding a new page for League Creation.... This page is garbage, but I think is the bare minimum 2 files to create a new webpage (the new `index.html` and the new controller).
The folder that the `index.html` file is in needs to match the filename of the python controller (*league_creation* in this case) and the url of the new page matches that name. Eg. this new page will be: https://dataprocessing.pythonanywhere.com/welcome/league_creation

I copied in the user.html to support logins/signups from this new page.... but we can always remove that if not necessary

Also added a small script to launch web2py locally without needing to open a new command prompt

It's currently junk, and not linked to anything, just a working example to build from. Eventually the python controller will probably have functionality added to create/store a new 'league' into the database